### PR TITLE
[gdbm]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.gdbm?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # gdbm
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# gdbm
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/gdbmtool'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/gdbmtool'
+command_relative_path: '/bin/gdbmtool'

--- a/controls/gdbm_exists.rb
+++ b/controls/gdbm_exists.rb
@@ -10,7 +10,7 @@ control 'core-plans-gdbm-exists' do
   impact 1.0
   title 'Ensure gdbm exists'
   desc '
-  Verify gdbm by ensuring /bin/gdbm exists'
+  Verify gdbm by ensuring /bin/gdbmtool exists'
   
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/gdbm_exists.rb
+++ b/controls/gdbm_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm gdbm exists'
+
+plan_name = input('plan_name', value: 'gdbm')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+gdbm_relative_path = input('command_path', value: '/bin/gdbmtool')
+gdbm_installation_directory = command("hab pkg path #{plan_ident}")
+gdbm_full_path = gdbm_installation_directory.stdout.strip + "#{ gdbm_relative_path}"
+ 
+control 'core-plans-gdbm-exists' do
+  impact 1.0
+  title 'Ensure gdbm exists'
+  desc '
+  '
+   describe file(gdbm_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/gdbm_exists.rb
+++ b/controls/gdbm_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gdbm exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdbm')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/gdbmtool')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-gdbm-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-gdbm-exists' do
   desc '
   Verify gdbm by ensuring /bin/gdbmtool exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/gdbmtool')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/gdbm_exists.rb
+++ b/controls/gdbm_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm gdbm exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdbm')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-gdbm_relative_path = input('command_path', value: '/bin/gdbmtool')
-gdbm_installation_directory = command("hab pkg path #{plan_ident}")
-gdbm_full_path = gdbm_installation_directory.stdout.strip + "#{ gdbm_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/gdbmtool')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-gdbm-exists' do
   impact 1.0
   title 'Ensure gdbm exists'
   desc '
-  '
-   describe file(gdbm_full_path) do
+  Verify gdbm by ensuring /bin/gdbm exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/gdbm_works.rb
+++ b/controls/gdbm_works.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm gdbm works as expected'
+
+plan_name = input('plan_name', value: 'gdbm')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+
+control 'core-plans-gdbm-works' do
+  impact 1.0
+  title 'Ensure gdbm works as expected'
+  desc '
+  '
+  gdbm_path = command("hab pkg path #{plan_ident}")
+  describe gdbm_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  gdbm_pkg_ident = ((gdbm_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("DEBUG=true; hab pkg exec #{ gdbm_pkg_ident} gdbmtool --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /gdbmtool \(gdbm\) 1.18.1/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/gdbm_works.rb
+++ b/controls/gdbm_works.rb
@@ -1,24 +1,28 @@
 title 'Tests to confirm gdbm works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdbm')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gdbm-works' do
   impact 1.0
   title 'Ensure gdbm works as expected'
   desc '
+  Verify gdbm by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  gdbm_path = command("hab pkg path #{plan_ident}")
-  describe gdbm_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  gdbm_pkg_ident = ((gdbm_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  describe command("DEBUG=true; hab pkg exec #{ gdbm_pkg_ident} gdbmtool --version") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gdbmtool --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /gdbmtool \(gdbm\) 1.18.1/ }
+    its('stdout') { should match /gdbmtool \(gdbm\) #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/controls/gdbm_works.rb
+++ b/controls/gdbm_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gdbm works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdbm')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gdbm-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-gdbm-works' do
   it returns the expected version
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gdbmtool --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: gdbm
+title: Habitat Core Plan gdbm
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan gdbm
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,60 @@
+pkg_name=gdbm
+pkg_origin=core
+pkg_version=1.18.1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+GNU dbm is a set of database routines that use extensible hashing. It works \
+similar to the standard UNIX dbm routines.\
+"
+pkg_upstream_url="http://www.gnu.org/software/gdbm/gdbm.html"
+pkg_license=('gplv3+')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
+pkg_build_deps=(
+  core/coreutils
+  core/dejagnu
+  core/diffutils
+  core/gcc
+  core/make
+  core/patch
+)
+pkg_deps=(core/glibc)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --enable-libgdbm-compat
+  make
+}
+
+do_check() {
+  make check
+}
+
+do_install() {
+  do_default_install
+
+  # create symlinks for compatibility
+  install -dm755 "$pkg_prefix/include/gdbm"
+  ln -sf ../gdbm.h "$pkg_prefix/include/gdbm/gdbm.h"
+  ln -sf ../ndbm.h "$pkg_prefix/include/gdbm/ndbm.h"
+  ln -sf ../dbm.h  "$pkg_prefix/include/gdbm/dbm.h"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(gdbmtool --version | head -1 | awk '{print $3}')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install --binlink core/bats
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install --binlink --force "results/${pkg_artifact}"
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://9e351438b9a952a06f394706df1a6b29680cd3908bfc8e096c075cb07ba1195b --input-file /src/attributes.yml

Profile: Habitat Core Plan gdbm (gdbm)
Version: 0.1.0
Target:  docker://9e351438b9a952a06f394706df1a6b29680cd3908bfc8e096c075cb07ba1195b

  ✔  core-plans-gdbm-works: Ensure gdbm works as expected
     ✔  Command: `hab pkg path core/gdbm` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/gdbm` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gdbm/1.18.1/20200603160731 gdbmtool --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/gdbm/1.18.1/20200603160731 gdbmtool --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gdbm/1.18.1/20200603160731 gdbmtool --version` stdout is expected to match /gdbmtool \(gdbm\) 1.18.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/gdbm/1.18.1/20200603160731 gdbmtool --version` stderr is expected to be empty
  ✔  core-plans-gdbm-exists: Ensure gdbm exists
     ✔  File /hab/pkgs/core/gdbm/1.18.1/20200603160731/bin/gdbmtool is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[8][default:/src:0]# 
```